### PR TITLE
Use tracing-actix-web to automatically handle request ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "pin-project"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-actix-web"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce52ffaf2d544e317d3bef63f49a6a22022866505fa4840a4339b1756834a2a9"
+dependencies = [
+ "actix-web",
+ "pin-project",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1297,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "tracing",
+ "tracing-actix-web",
  "tracing-bunyan-formatter",
  "tracing-log",
  "tracing-subscriber",

--- a/src/webapi/Cargo.toml
+++ b/src/webapi/Cargo.toml
@@ -9,5 +9,5 @@ tracing = "0.1"
 tracing-bunyan-formatter = "0.3"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-log = "0.1" 
+tracing-actix-web = "0.7"
 uuid = { version = "1.4.1", features = ["v4"] }
-

--- a/src/webapi/src/main.rs
+++ b/src/webapi/src/main.rs
@@ -1,6 +1,7 @@
 mod routes;
 
 use actix_web::{App, HttpServer};
+use tracing_actix_web::TracingLogger;
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
@@ -20,8 +21,12 @@ fn initialize_tracing() {
 async fn main() -> std::io::Result<()> {
     initialize_tracing();
 
-    HttpServer::new(|| App::new().service(routes::infra::ping))
-        .bind(("0.0.0.0", 8081))?
-        .run()
-        .await
+    HttpServer::new(|| {
+        App::new()
+            .wrap(TracingLogger::default())
+            .service(routes::infra::ping)
+    })
+    .bind(("0.0.0.0", 8081))?
+    .run()
+    .await
 }

--- a/src/webapi/src/routes/infra.rs
+++ b/src/webapi/src/routes/infra.rs
@@ -1,13 +1,7 @@
 use actix_web::{get, HttpResponse, Responder};
-use uuid::Uuid;
 
 #[get("/ping")]
-#[tracing::instrument(
-    name = "Ping request", 
-    fields(
-        request_id = %Uuid::new_v4(),
-    )
-)]
+#[tracing::instrument(name = "Ping request")]
 pub(crate) async fn ping() -> impl Responder {
     HttpResponse::Ok().json("pong")
 }


### PR DESCRIPTION
When wrapping just the route handlers with generated request ids we can't have the same request id in actix logs. This fixes that and reuses the same request id in child spans.

For more details see chapter 4.5.14 of https://zero2prod.com